### PR TITLE
Need to update the scorec package for MeshAdapt capabilities in Proteus 

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -17,6 +17,7 @@ bld.bat text eol=crlf
 .gitattributes linguist-generated=true
 .gitignore linguist-generated=true
 .travis.yml linguist-generated=true
+.scripts linguist-generated=true
 LICENSE.txt linguist-generated=true
 README.md linguist-generated=true
 azure-pipelines.yml linguist-generated=true

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @davidbrochart
+* @SylvainCorlay @davidbrochart

--- a/README.md
+++ b/README.md
@@ -170,4 +170,5 @@ Feedstock Maintainers
 
 * [@SylvainCorlay](https://github.com/SylvainCorlay/)
 * [@davidbrochart](https://github.com/davidbrochart/)
+* [@zhang-alvin](https://github.com/zhang-alvin/)
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ A feedstock is made up of a conda recipe (the instructions on what and how to bu
 the package) and the necessary configurations for automatic building using freely
 available continuous integration services. Thanks to the awesome service provided by
 [CircleCI](https://circleci.com/), [AppVeyor](https://www.appveyor.com/)
-and [TravisCI](https://travis-ci.org/) it is possible to build and upload installable
+and [TravisCI](https://travis-ci.com/) it is possible to build and upload installable
 packages to the [conda-forge](https://anaconda.org/conda-forge)
 [Anaconda-Cloud](https://anaconda.org/) channel for Linux, Windows and OSX respectively.
 
@@ -168,5 +168,6 @@ In order to produce a uniquely identifiable distribution:
 Feedstock Maintainers
 =====================
 
+* [@SylvainCorlay](https://github.com/SylvainCorlay/)
 * [@davidbrochart](https://github.com/davidbrochart/)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "scorec" %}
-{% set version = "2.2.1-63-g2cdb8ef" %}
+{% set version = "2.2.1.63.g2cdb8ef" %}
 {% set build = 0 %}
 {% set sha256 = "e6a942d21c067e4242a5dd4267749e8f72d31a2dede245cc0ca8b5f223015c88" %}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "scorec" %}
-{% set version = "20161004" %}
+{% set version = "20200108" %}
 {% set build = 1 %}
-{% set sha256 = "f43585af3c45fa6d76e476596ccc950ab1dab9d3588d7d46ced9b88c4859eb0b" %}
+{% set sha256 = "4619856df9cecd66cc060eb02afeb34c959f0a6ce551d6840673d343a8ea6619" %}
 
 {% set mpi = mpi or 'mpich' %}
 
@@ -10,8 +10,8 @@ package:
   version: {{ version }}
 
 source:
-  fn: scorec_after_sim.tar.gz
-  url: https://github.com/SCOREC/core/archive/after_sim.tar.gz
+  fn: SCOREC-core-2.2.1-63-g2cdb8ef.tar.gz
+  url: https://github.com/SCOREC/core/tarball/2cdb8ef4b1ff0cc6a6cd457fa44da7ea9784cb93
   sha256: {{ sha256 }}
   patches:
     - 0001-fix-malloc-usage.patch  # [osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://github.com/SCOREC/core/archive/v2.2.2.tar.gz
+  url: https://github.com/SCOREC/core/archive/v{{ version }}.tar.gz
   sha256: {{ sha256 }}
 #  patches:
 #    - 0001-fix-malloc-usage.patch  # [osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "scorec" %}
 {% set version = "20200108" %}
-{% set build = 1 %}
+{% set build = 0 %}
 {% set sha256 = "4619856df9cecd66cc060eb02afeb34c959f0a6ce551d6840673d343a8ea6619" %}
 
 {% set mpi = mpi or 'mpich' %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,9 +13,9 @@ source:
   fn: SCOREC-core-2.2.1-63-g2cdb8ef.tar.gz
   url: https://github.com/SCOREC/core/tarball/2cdb8ef4b1ff0cc6a6cd457fa44da7ea9784cb93
   sha256: {{ sha256 }}
-  patches:
-    - 0001-fix-malloc-usage.patch  # [osx]
-    - 0002-fmemopen-memstream-ports-for-darwin.patch  # [osx]
+#  patches:
+#    - 0001-fix-malloc-usage.patch  # [osx]
+#    - 0002-fmemopen-memstream-ports-for-darwin.patch  # [osx]
 
 build:
   number: {{ build }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "scorec" %}
-{% set version = "2.2.1.63.g2cdb8ef" %}
+{% set version = "2.2.2" %}
 {% set build = 0 %}
-{% set sha256 = "e6a942d21c067e4242a5dd4267749e8f72d31a2dede245cc0ca8b5f223015c88" %}
+{% set sha256 = "201ba8ad9f71e75fd2d6d7dc6da43dafd69233a16e022786c85f62c207fcbf0f" %}
 
 {% set mpi = mpi or 'mpich' %}
 
@@ -10,8 +10,7 @@ package:
   version: {{ version }}
 
 source:
-  #fn: SCOREC-core-2.2.1-63-g2cdb8ef.tar.gz
-  url: https://github.com/SCOREC/core/archive/2.2.1-63-g2cdb8ef.tar.gz
+  url: https://github.com/SCOREC/core/archive/v2.2.2.tar.gz
   sha256: {{ sha256 }}
 #  patches:
 #    - 0001-fix-malloc-usage.patch  # [osx]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,3 +49,4 @@ extra:
   recipe-maintainers:
     - davidbrochart
     - SylvainCorlay
+    - zhang-alvin

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 {% set name = "scorec" %}
-{% set version = "20200108" %}
+{% set version = "2.2.1-63-g2cdb8ef" %}
 {% set build = 0 %}
-{% set sha256 = "4619856df9cecd66cc060eb02afeb34c959f0a6ce551d6840673d343a8ea6619" %}
+{% set sha256 = "e6a942d21c067e4242a5dd4267749e8f72d31a2dede245cc0ca8b5f223015c88" %}
 
 {% set mpi = mpi or 'mpich' %}
 
@@ -10,8 +10,8 @@ package:
   version: {{ version }}
 
 source:
-  fn: SCOREC-core-2.2.1-63-g2cdb8ef.tar.gz
-  url: https://github.com/SCOREC/core/tarball/2cdb8ef4b1ff0cc6a6cd457fa44da7ea9784cb93
+  #fn: SCOREC-core-2.2.1-63-g2cdb8ef.tar.gz
+  url: https://github.com/SCOREC/core/archive/2.2.1-63-g2cdb8ef.tar.gz
   sha256: {{ sha256 }}
 #  patches:
 #    - 0001-fix-malloc-usage.patch  # [osx]


### PR DESCRIPTION
The latest release of scorec does not have the necessary features for Proteus to compile properly, so I'm basing this version around a recent commit in the master branch.  

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
