### PR TITLE
Bump build number to retry a flaked osx-64 job

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "scorec" %}
 {% set version = "2.2.8" %}
-{% set build = 9 %}
+{% set build = 10 %}
 {% set sha256 = "5216d0d5ac031c9357a59986b1bc6f2cbdbac0356059e98a2bec78c1777a59e2" %}
 
 {% if mpi is not defined %}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "scorec" %}
 {% set version = "2.2.8" %}
-{% set build = 10 %}
+{% set build = 11 %}
 {% set sha256 = "5216d0d5ac031c9357a59986b1bc6f2cbdbac0356059e98a2bec78c1777a59e2" %}
 
 {% if mpi is not defined %}


### PR DESCRIPTION
The post-merge main build for #28 had one unrelated failure (osx_64_metis5.2.1mpimpich): the runner's own bootstrap step failed to solve python/conda-build/pip from the channel ("does not exist (perhaps a typo or a missing channel)") -- a transient CI infra hiccup during environment setup, before this recipe or its arm64 changes were even touched. All three osx-arm64 variants (the actual point of #28) succeeded cleanly. No access to Azure's own "retry failed job" UI, so retriggering via a build-number bump instead.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
