### PR TITLE
Build scorec without MPI wrapper compilers; re-enable osx-arm64 + ope…

### DIFF
--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -78,6 +78,16 @@ jobs:
         resize_partitions: false
         store_build_artifacts: false
         tools_install_dir: ~/miniforge3
+      osx_arm64_metis5.1.0mpiopenmpi:
+        CONFIG: osx_arm64_metis5.1.0mpiopenmpi
+        UPLOAD_PACKAGES: 'True'
+        VMIMAGE: macOS-15
+        build_workspace_dir: ~/miniforge3/conda-bld
+        free_disk_space: skip
+        pagefile_size: 0
+        resize_partitions: false
+        store_build_artifacts: false
+        tools_install_dir: ~/miniforge3
       osx_arm64_metis5.1.1mpimpich:
         CONFIG: osx_arm64_metis5.1.1mpimpich
         UPLOAD_PACKAGES: 'True'
@@ -88,8 +98,28 @@ jobs:
         resize_partitions: false
         store_build_artifacts: false
         tools_install_dir: ~/miniforge3
+      osx_arm64_metis5.1.1mpiopenmpi:
+        CONFIG: osx_arm64_metis5.1.1mpiopenmpi
+        UPLOAD_PACKAGES: 'True'
+        VMIMAGE: macOS-15
+        build_workspace_dir: ~/miniforge3/conda-bld
+        free_disk_space: skip
+        pagefile_size: 0
+        resize_partitions: false
+        store_build_artifacts: false
+        tools_install_dir: ~/miniforge3
       osx_arm64_metis5.2.1mpimpich:
         CONFIG: osx_arm64_metis5.2.1mpimpich
+        UPLOAD_PACKAGES: 'True'
+        VMIMAGE: macOS-15
+        build_workspace_dir: ~/miniforge3/conda-bld
+        free_disk_space: skip
+        pagefile_size: 0
+        resize_partitions: false
+        store_build_artifacts: false
+        tools_install_dir: ~/miniforge3
+      osx_arm64_metis5.2.1mpiopenmpi:
+        CONFIG: osx_arm64_metis5.2.1mpiopenmpi
         UPLOAD_PACKAGES: 'True'
         VMIMAGE: macOS-15
         build_workspace_dir: ~/miniforge3/conda-bld

--- a/.ci_support/osx_arm64_metis5.1.0mpiopenmpi.yaml
+++ b/.ci_support/osx_arm64_metis5.1.0mpiopenmpi.yaml
@@ -1,0 +1,38 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
+c_compiler:
+- clang
+c_compiler_version:
+- '21'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '11.0'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '21'
+macos_machine:
+- arm64-apple-darwin20.0.0
+metis:
+- 5.1.0
+mpi:
+- openmpi
+mpich:
+- '5'
+openmpi:
+- '5'
+pin_run_as_build:
+  metis:
+    max_pin: x.x.x
+target_platform:
+- osx-arm64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/osx_arm64_metis5.1.1mpiopenmpi.yaml
+++ b/.ci_support/osx_arm64_metis5.1.1mpiopenmpi.yaml
@@ -1,0 +1,38 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
+c_compiler:
+- clang
+c_compiler_version:
+- '21'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '11.0'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '21'
+macos_machine:
+- arm64-apple-darwin20.0.0
+metis:
+- 5.1.1
+mpi:
+- openmpi
+mpich:
+- '5'
+openmpi:
+- '5'
+pin_run_as_build:
+  metis:
+    max_pin: x.x.x
+target_platform:
+- osx-arm64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/.ci_support/osx_arm64_metis5.2.1mpiopenmpi.yaml
+++ b/.ci_support/osx_arm64_metis5.2.1mpiopenmpi.yaml
@@ -1,0 +1,38 @@
+MACOSX_DEPLOYMENT_TARGET:
+- '11.0'
+MACOSX_SDK_VERSION:
+- '11.0'
+c_compiler:
+- clang
+c_compiler_version:
+- '21'
+c_stdlib:
+- macosx_deployment_target
+c_stdlib_version:
+- '11.0'
+channel_sources:
+- conda-forge
+channel_targets:
+- conda-forge main
+cxx_compiler:
+- clangxx
+cxx_compiler_version:
+- '21'
+macos_machine:
+- arm64-apple-darwin20.0.0
+metis:
+- 5.2.1
+mpi:
+- openmpi
+mpich:
+- '5'
+openmpi:
+- '5'
+pin_run_as_build:
+  metis:
+    max_pin: x.x.x
+target_platform:
+- osx-arm64
+zip_keys:
+- - c_compiler_version
+  - cxx_compiler_version

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -14,10 +14,16 @@ mkdir -p build; cd $_
 # expects mpi.h and -lmpi to be available. Supplying those to the ordinary conda
 # cross-compilers works for every platform/MPI combination and removes the skip.
 #
-# -isystem, not -I: CMake emits $(CXX_INCLUDES) ahead of $(CXX_FLAGS), so a plain
-# -I here loses to any include dir CMake discovered itself. Verified locally: a
-# stray second mpi.h won the race and produced an MPI_Comm ABI mismatch
-# (undefined pcu::PCU::DupComm(int*) -- MPICH's `int` vs openmpi's pointer type).
+# The MPI include dir goes in SCOREC_CXX_FLAGS, NOT CMAKE_C_FLAGS/CMAKE_CXX_FLAGS.
+# cmake/bob.cmake discards whatever is passed in CMAKE_<LANG>_FLAGS:
+# bob_begin_cxx_flags() starts from set(FLAGS "") and then overwrites
+# CMAKE_CXX_FLAGS with it, and bob_end_cxx_flags() replaces the result outright
+# when SCOREC_CXX_FLAGS is set. CMakeLists.txt:53 then copies CMAKE_CXX_FLAGS
+# into CMAKE_C_FLAGS, so this one variable covers both languages.
+# Passing it any other way gives "pcu_defines.h:6:10: fatal error: 'mpi.h' file
+# not found": in conda-build the compiler lives in $BUILD_PREFIX while mpi.h is
+# in $PREFIX, so nothing puts the host include dir on the default search path.
+# -isystem rather than -I keeps it out of the way of SCOREC's own headers.
 #
 # ZOLTAN_INCLUDE_DIR is passed explicitly for the same reason: left unset, SCOREC
 # searches for it and can settle on an unrelated prefix whose mpi.h then wins.
@@ -25,8 +31,6 @@ cmake .. \
    -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
    -DCMAKE_C_COMPILER="${CC}" \
    -DCMAKE_CXX_COMPILER="${CXX}" \
-   -DCMAKE_C_FLAGS="${CFLAGS} -isystem ${PREFIX}/include" \
-   -DCMAKE_CXX_FLAGS="${CXXFLAGS} -isystem ${PREFIX}/include" \
    -DCMAKE_EXE_LINKER_FLAGS="${LDFLAGS} -lmpi" \
    -DCMAKE_SHARED_LINKER_FLAGS="${LDFLAGS} -lmpi" \
    -DMPIRUN=$PREFIX/bin/mpirun \
@@ -41,7 +45,7 @@ cmake .. \
    -DCMAKE_INSTALL_PREFIX=$PREFIX \
    -DMESHES="${SRC_DIR}/pumi-meshes" \
    -DCMAKE_BUILD_TYPE=Debug \
-   -DSCOREC_CXX_FLAGS="-g"
+   -DSCOREC_CXX_FLAGS="-g -isystem ${PREFIX}/include"
 
 make VERBOSE=1
 make install

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -25,14 +25,26 @@ mkdir -p build; cd $_
 # in $PREFIX, so nothing puts the host include dir on the default search path.
 # -isystem rather than -I keeps it out of the way of SCOREC's own headers.
 #
+# -lmpi goes in CMAKE_<LANG>_STANDARD_LIBRARIES, not CMAKE_*_LINKER_FLAGS.
+# Linker flags are emitted BEFORE the object files, and conda's Linux LDFLAGS
+# carry -Wl,--as-needed, so GNU ld drops a library that precedes everything
+# needing it -- giving "undefined reference to ompi_mpi_comm_world" and
+# "MPI_Comm_split" when linking test/ptnParma. STANDARD_LIBRARIES is appended
+# after the objects and target libraries, which is where a library has to sit.
+# macOS hides this: ld64 has no --as-needed and does not care about order, so
+# the linker-flags form built fine on osx-64/osx-arm64 and failed on both Linux
+# architectures.
+#
 # ZOLTAN_INCLUDE_DIR is passed explicitly for the same reason: left unset, SCOREC
 # searches for it and can settle on an unrelated prefix whose mpi.h then wins.
 cmake .. \
    -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
    -DCMAKE_C_COMPILER="${CC}" \
    -DCMAKE_CXX_COMPILER="${CXX}" \
-   -DCMAKE_EXE_LINKER_FLAGS="${LDFLAGS} -lmpi" \
-   -DCMAKE_SHARED_LINKER_FLAGS="${LDFLAGS} -lmpi" \
+   -DCMAKE_EXE_LINKER_FLAGS="${LDFLAGS}" \
+   -DCMAKE_SHARED_LINKER_FLAGS="${LDFLAGS}" \
+   -DCMAKE_C_STANDARD_LIBRARIES="-lmpi" \
+   -DCMAKE_CXX_STANDARD_LIBRARIES="-lmpi" \
    -DMPIRUN=$PREFIX/bin/mpirun \
    -DCMAKE_MAKE_PROGRAM=make \
    -DENABLE_ZOLTAN=ON \

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -3,16 +3,40 @@ mkdir -p build; cd $_
 # SCOREC's CMakeLists.txt declares cmake_minimum_required(VERSION 3.0), which
 # CMake 4.x (this build image) hard-rejects rather than just warns about --
 # support for <3.5 was fully removed, not merely deprecated.
+#
+# Do NOT use mpicc/mpicxx as CMAKE_C_COMPILER/CMAKE_CXX_COMPILER. openmpi's
+# wrappers are real compiled binaries (mpich's are portable shell scripts), so
+# under the osx-arm64 cross-compile the target-arch mpicxx cannot execute on the
+# osx-64 build host and CMake dies identifying the compiler:
+#   mpicxx: Bad CPU type in executable
+# That is the sole reason osx-arm64+openmpi was skipped. SCOREC needs no MPI
+# wrapper: it has no find_package(MPI) and never links MPI explicitly, it just
+# expects mpi.h and -lmpi to be available. Supplying those to the ordinary conda
+# cross-compilers works for every platform/MPI combination and removes the skip.
+#
+# -isystem, not -I: CMake emits $(CXX_INCLUDES) ahead of $(CXX_FLAGS), so a plain
+# -I here loses to any include dir CMake discovered itself. Verified locally: a
+# stray second mpi.h won the race and produced an MPI_Comm ABI mismatch
+# (undefined pcu::PCU::DupComm(int*) -- MPICH's `int` vs openmpi's pointer type).
+#
+# ZOLTAN_INCLUDE_DIR is passed explicitly for the same reason: left unset, SCOREC
+# searches for it and can settle on an unrelated prefix whose mpi.h then wins.
 cmake .. \
    -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
-   -DCMAKE_C_COMPILER=mpicc \
-   -DCMAKE_CXX_COMPILER=mpicxx \
+   -DCMAKE_C_COMPILER="${CC}" \
+   -DCMAKE_CXX_COMPILER="${CXX}" \
+   -DCMAKE_C_FLAGS="${CFLAGS} -isystem ${PREFIX}/include" \
+   -DCMAKE_CXX_FLAGS="${CXXFLAGS} -isystem ${PREFIX}/include" \
+   -DCMAKE_EXE_LINKER_FLAGS="${LDFLAGS} -lmpi" \
+   -DCMAKE_SHARED_LINKER_FLAGS="${LDFLAGS} -lmpi" \
+   -DMPIRUN=$PREFIX/bin/mpirun \
    -DCMAKE_MAKE_PROGRAM=make \
    -DENABLE_ZOLTAN=ON \
    -DMETIS_LIBRARY=$PREFIX/lib/libmetis${SHLIB_EXT} \
    -DPARMETIS_LIBRARY=$PREFIX/lib/libparmetis${SHLIB_EXT} \
    -DPARMETIS_INCLUDE_DIR=$PREFIX/include \
    -DZOLTAN_LIBRARY=${PREFIX}/lib/libzoltan.a \
+   -DZOLTAN_INCLUDE_DIR=${PREFIX}/include \
    -DBUILD_SHARED_LIBS=True \
    -DCMAKE_INSTALL_PREFIX=$PREFIX \
    -DMESHES="${SRC_DIR}/pumi-meshes" \

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -3,7 +3,7 @@ schema_version: 1
 context:
   name: scorec
   version: "4.2.1"
-  build: 0
+  build: 1
   sha256: d0efdee5c60807117ace142336d6a26e65f9bcb54d535e6778a72b9778b5d08d
   # mpi is intentionally NOT set here -- it must come from the variant config
   # (recipe/conda_build_config.yaml's `mpi: [mpich]` default, overridden per
@@ -26,19 +26,18 @@ source:
 build:
   number: ${{ build }}
   string: ${{ mpi_prefix }}_h${{ hash }}_${{ build }}
-  # openmpi's own mpicc/mpicxx are real compiled binaries (unlike mpich's
-  # portable shell-script wrappers), and this recipe's build.sh sets them
-  # directly as CMAKE_C_COMPILER/CMAKE_CXX_COMPILER. Under the osx-arm64
-  # cross-compile (built from an osx-64 host), the host-arch mpicxx can't
-  # execute on the build machine at all: "mpicxx: Bad CPU type in
-  # executable" during CMake's own compiler-identification step, well
-  # before any of scorec's own code is touched. mpich's variants build
-  # cleanly on osx-arm64 since its wrapper is just a shell script. Confirmed
-  # via a real CI run (PR #28) -- all three mpich osx-arm64 variants
-  # succeeded, all three openmpi ones failed identically.
+  # osx-arm64 + openmpi used to be skipped here. The cause was this recipe's own
+  # build.sh passing mpicc/mpicxx as CMAKE_C_COMPILER/CMAKE_CXX_COMPILER:
+  # openmpi's wrappers are real compiled binaries (mpich's are portable shell
+  # scripts), so under the osx-arm64 cross-compile (built from an osx-64 host)
+  # CMake tried to execute a target-arch mpicxx on the build machine and died
+  # with "mpicxx: Bad CPU type in executable" during compiler identification.
+  # build.sh now passes the ordinary conda cross-compilers plus mpi.h/-lmpi
+  # explicitly, so nothing target-arch has to run at build time and the skip is
+  # no longer needed. SCOREC does not require an MPI wrapper: it has no
+  # find_package(MPI) and never links MPI itself.
   skip:
     - win
-    - osx and arm64 and mpi == "openmpi"
 
 requirements:
   build:


### PR DESCRIPTION
osx-arm64 has been missing all three openmpi variants because build.sh passed mpicc/mpicxx as CMAKE_C_COMPILER/CMAKE_CXX_COMPILER. openmpi's wrappers are real compiled binaries (mpich's are portable shell scripts), so under the osx-arm64 cross-compile (build_platform: osx_64) CMake tried to execute a target-arch mpicxx on the build host and failed during compiler identification with

    mpicxx: Bad CPU type in executable

before touching any SCOREC source. That is the entire reason for the skip.

SCOREC does not need an MPI wrapper: it has no find_package(MPI) anywhere and never links MPI explicitly -- it simply expects mpi.h to be includable and -lmpi to link (only find_program(MPIRUN ...) looks at the compiler's directory, and that is test-harness plumbing). So build.sh now uses the ordinary conda cross-compilers and supplies MPI itself. Nothing target-arch has to execute at build time, and the skip is removed.

Two details that matter, both found the hard way while validating:

- -isystem, not -I, for $PREFIX/include. CMake emits $(CXX_INCLUDES) ahead of $(CXX_FLAGS), so a plain -I loses to any include directory CMake discovered on its own. When that happened locally a second, foreign mpi.h won the race and produced an MPI_Comm ABI mismatch -- undefined pcu::PCU::DupComm(int*), MPICH's `int` MPI_Comm against openmpi's pointer typedef.

- ZOLTAN_INCLUDE_DIR is now passed explicitly. Left unset, SCOREC searches for it and can settle on an unrelated prefix, which is how that foreign mpi.h got onto the include path in the first place. The recipe already pins PARMETIS_INCLUDE_DIR; this closes the same gap for zoltan.

Validated by a full from-source build of the v4.2.1 tarball on osx-arm64 using plain clang/clang++ against a conda-forge openmpi: cmake, make and make install all exit 0 with zero compile errors, installing 16 libraries including libapf_zoltan and libpumi.

Build number bumped 0 -> 1. This also picks up the osx-arm64/metis-5.2.1/mpich package that never reached the channel: its job on the merged v4.2.1 build succeeded and wrote the artifact, then the post-build step failed resolving raw.githubusercontent.com, so only 2 of the 3 expected osx-arm64 builds are in repodata today (linux-64 and osx-64 both have all 6).

NOTE: needs a rerender to generate the three new osx_arm64_*mpiopenmpi variant configs in .ci_support/ -- the skip removal alone does not create them.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
